### PR TITLE
Image resize did not work on WPML sites

### DIFF
--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -217,9 +217,30 @@ class TimberImageTest extends WP_UnitTestCase {
 
 	function testResizeFileNaming() {
 		$file_loc = self::copyTestImage( 'eastern.jpg' );
-		$filename = TimberImageHelper::get_resize_file_rel( $file_loc, 300, 500, 'default' );
+		$filename = TimberImageHelper::get_resize_file_url( $file_loc, 300, 500, 'default' );
 		$upload_dir = wp_upload_dir();
 		$this->assertEquals( $upload_dir['relative'].$upload_dir['subdir'].'/eastern-300x500-c-default.jpg', $filename );
+	}
+
+	function testResizeFileNamingWithAbsoluteURL() {
+		$file_loc = self::copyTestImage( 'eastern.jpg' );
+		$upload_dir = wp_upload_dir();
+		$url_src = $upload_dir['url'].'/eastern.jpg';
+		$filename = TimberImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
+		$this->assertEquals( $upload_dir['url'].'/eastern-300x500-c-default.jpg', $filename );
+	}
+
+	function add_lang_to_home( $url, $path, $orig_scheme, $blog_id ){
+		return "$url?lang=en";
+	}
+
+	function testResizeFileNamingWithLangHome() {
+		add_filter( 'home_url', array($this,'add_lang_to_home') , 1, 4 );
+		$file_loc = self::copyTestImage( 'eastern.jpg' );
+		$upload_dir = wp_upload_dir();
+		$url_src = $upload_dir['url'].'/eastern.jpg';
+		$filename = TimberImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
+		$this->assertEquals( $upload_dir['url'].'/eastern-300x500-c-default.jpg', $filename );
 	}
 
 	function testLetterboxFileNaming() {

--- a/timber.php
+++ b/timber.php
@@ -11,9 +11,12 @@ Author URI: http://upstatement.com/
 global $wp_version;
 global $timber;
 
-$composer_autoload = __DIR__ . '/vendor/autoload.php';
-if (file_exists($composer_autoload)){
-	require_once($composer_autoload);
+// we look for Composer files first in the theme (theme install)
+// then in the wp-content dir (site install)
+if (file_exists($composer_autoload = __DIR__ . '/vendor/autoload.php')){
+  require_once($composer_autoload);
+} else if(file_exists($composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php')){
+  require_once($composer_autoload);
 }
 
 require_once(__DIR__ . '/functions/timber-twig.php');


### PR DESCRIPTION
Hi,

tl;dr: Using the resize filter on a site with WPML translations resulted in broken resized image links, I fixed it (and added non-regression tests).

More details:
- WPML works by changing home_url() from 'example.com' to 'example.com?lang=en'
- timber resize used to build resized url by doing home_url().'...path...'
- mixing the 2 resulted in broken url of 'example.com **?lang=en** /wp-content/.../img-300x500-c-default.jpg'
- I updated resize to use content_url(), which WPML does not touch
- I very slightly refactored timber-image-helper in the process.

Thanks