### PR TITLE
Fix composer install error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,36 @@
 {
-	"name"       : "jarednova/timber",
-	"type"       : "wordpress-plugin",
-	"description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
-	"keywords"   : ["timber", "twig", "themes", "templating"],
-	"homepage"   : "http://timber.upstatement.com",
-	"license"    : "MIT",
-	"authors"    : [
-		{
-			"name"    : "Jared Novack",
-			"email"   : "jared@upstatement.com",
-			"homepage": "http://upstatement.com"
-		}
-	],
-	"support"    : {
-		"issues": "https://github.com/jarednova/timber/issues",
-		"wiki"  : "https://github.com/jarednova/timber/wiki",
-		"source": "https://github.com/jarednova/timber"
-	},
-	"require"    : {
-		"php"                		: ">=5.3.0",
-		"twig/twig"			 		: "~1.15",
-		"dannyvankooten/php-router"	: "dev-master#e9a479820b871ae4493fec30d5e433456767a505",
-		"composer/installers"		: "~1.0",
-		"asm89/twig-cache-extension": "~0.1"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "3.7.*",
+    "name": "jarednova/timber",
+    "type": "wordpress-plugin",
+    "description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
+    "keywords": ["timber", "twig", "themes", "templating"],
+    "homepage": "http://timber.upstatement.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jared Novack",
+            "email": "jared@upstatement.com",
+            "homepage": "http://upstatement.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/jarednova/timber/issues",
+        "wiki": "https://github.com/jarednova/timber/wiki",
+        "source": "https://github.com/jarednova/timber"
+    },
+    "require": {
+        "php": ">=5.3.0",
+        "twig/twig": "~1.15",
+        "dannyvankooten/php-router": "1.0.0-alpha",
+        "composer/installers": "~1.0",
+        "asm89/twig-cache-extension": "~0.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*",
         "satooshi/php-coveralls": "dev-master",
-        "AdvancedCustomFields/acf5-beta" : "5.0",
-        "wp-cli/wp-cli" : "*"
-	},
-	"repositories": [
+        "AdvancedCustomFields/acf5-beta": "5.0",
+        "wp-cli/wp-cli": "*"
+    },
+    "repositories": [
         {
             "type": "package",
             "package": {
@@ -41,7 +41,9 @@
                     "type": "zip"
                 },
                 "autoload": {
-                    "psr-0": { "acf\\advanced-custom-fields-pro": "" }
+                    "psr-0": {
+                        "acfadvanced-custom-fields-pro": ""
+                    }
                 },
                 "target-dir": "acf/advanced-custom-fields-pro"
             }


### PR DESCRIPTION
fixes no matching package found due to requiring dev-master of
dannyvankooten/php-router

by default composer has "minimum-stability" set to "stable" now, so you
should not be using dev-master