### PR TITLE
426 trailing slash

### DIFF
--- a/functions/timber-menu-item.php
+++ b/functions/timber-menu-item.php
@@ -106,7 +106,7 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
      * @return string
      */
     function get_path() {
-        return TimberURLHelper::remove_trailing_slash( TimberURLHelper::get_rel_url( $this->get_link() ) );
+        return TimberURLHelper::get_rel_url( $this->get_link() );
     }
 
     /**

--- a/functions/timber-menu-item.php
+++ b/functions/timber-menu-item.php
@@ -29,9 +29,6 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
         $this->name = $this->name();
         $this->add_class( 'menu-item-' . $this->ID );
         $this->menu_object = $data;
-        if ( isset( $this->url ) && $this->url ) {
-            $this->url = TimberURLHelper::remove_trailing_slash( $this->url );
-        }
     }
 
     function __toString() {

--- a/functions/timber-menu-item.php
+++ b/functions/timber-menu-item.php
@@ -97,7 +97,7 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
                     $this->url = $this->menu_object->get_link();
                 }
         }
-        return TimberURLHelper::remove_trailing_slash( $this->url );
+        return $this->url;
     }
 
     /**

--- a/functions/timber-menu-item.php
+++ b/functions/timber-menu-item.php
@@ -158,6 +158,11 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
         return TimberURLHelper::is_external( $this->url );
     }
 
+    /**
+     *
+     * @param $key string lookup key
+     * @return mixed whatever value is storied in the database
+     */
     public function meta( $key ) {
         if ( is_object( $this->menu_object ) && method_exists( $this->menu_object, 'meta' ) ) {
             return $this->menu_object->meta( $key );
@@ -190,7 +195,7 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
     /**
      *
      *
-     * @return string
+     * @return string a full URL like http://mysite.com/thing/
      */
     public function link() {
         return $this->get_link();
@@ -198,8 +203,8 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
 
     /**
      *
-     *
-     * @return string
+     * @see get_path()
+     * @return string the path of a URL like /foo
      */
     public function path() {
         return $this->get_path();
@@ -207,8 +212,8 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
 
     /**
      *
-     *
-     * @return string
+     * @see link()
+     * @return string a full URL like http://mysite.com/thing/
      */
     public function permalink() {
         return $this->get_link();
@@ -216,13 +221,18 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
 
     /**
      *
-     *
-     * @return string
+     * @see link()
+     * @return string a full URL like http://mysite.com/thing/
      */
     public function get_permalink() {
         return $this->get_link();
     }
 
+    /**
+     *
+     *
+     * @return string the public label like Foo
+     */
     public function title() {
         if (isset($this->__title)){
             return $this->__title;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jarednova
 Tags: template engine, templates, twig
 Requires at least: 3.7
 Stable tag: 0.20.8
-Tested up to: 4.0
+Tested up to: 4.1
 PHP version: 5.3.0 or greater
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -18,6 +18,8 @@
         function testWPTitle(){
         	//since we're testing with twentyfourteen -- need to remove its filters on wp_title
         	remove_all_filters('wp_title');
+            remove_theme_support( 'title-tag' );
+
         	$this->assertEquals('', TimberHelper::get_wp_title());
         }
 

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -12,15 +12,25 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'home', $item->slug() );
 		$this->assertFalse( $item->is_external() );
 		$struc = get_option( 'permalink_structure' );
-		$this->assertEquals( 'http://example.org/home', $item->permalink() );
-		$this->assertEquals( 'http://example.org/home', $item->get_permalink() );
-		$this->assertEquals( 'http://example.org/home', $item->url );
-		$this->assertEquals( 'http://example.org/home', $item->link() );
-		$this->assertEquals( '/home', $item->path() );
+		$this->assertEquals( 'http://example.org/home/', $item->permalink() );
+		$this->assertEquals( 'http://example.org/home/', $item->get_permalink() );
+		$this->assertEquals( 'http://example.org/home/', $item->url );
+		$this->assertEquals( 'http://example.org/home/', $item->link() );
+		$this->assertEquals( '/home/', $item->path() );
 	}
 
 	function testTrailingSlashesOrNot() {
 		$this->setPermalinkStructure();
+		$items = array();
+		$items[] = (object) array('type' => 'link', 'link' => '/');
+		$items[] = (object) array('type' => 'link', 'link' => '/foo');
+		$items[] = (object) array('type' => 'link', 'link' => '/bar/');
+		$mid = $this->buildMenu('Blanky', $items);
+		$menu = new TimberMenu($mid);
+		$items = $menu->get_items();
+		$this->assertEquals('/', $items[0]->path());
+		$this->assertEquals('/foo', $items[1]->path());
+		$this->assertEquals('/bar/', $items[2]->path());
 	}
 
 	function testPagesMenu() {
@@ -54,7 +64,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$str = Timber::compile( 'assets/child-menu.twig', $context );
 		$str = preg_replace( '/\s+/', '', $str );
 		$str = preg_replace( '/\s+/', '', $str );
-		$this->assertStringStartsWith( '<ulclass="navnavbar-nav"><li><ahref="http://example.org/home"class="has-children">Home</a><ulclass="dropdown-menu"role="menu"><li><ahref="http://example.org/child-page">ChildPage</a></li></ul><li><ahref="http://upstatement.com"class="no-children">Upstatement</a><li><ahref="/"class="no-children">RootHome</a>', $str );
+		$this->assertStringStartsWith( '<ulclass="navnavbar-nav"><li><ahref="http://example.org/home/"class="has-children">Home</a><ulclass="dropdown-menu"role="menu"><li><ahref="http://example.org/child-page/">ChildPage</a></li></ul><li><ahref="http://upstatement.com"class="no-children">Upstatement</a><li><ahref="/"class="no-children">RootHome</a>', $str );
 	}
 
 	function testMenuTwigWithClasses() {
@@ -69,7 +79,6 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$this->assertContains( 'current-menu-item', $str );
 		$this->assertContains( 'menu-item-object-page', $str );
 		$this->assertNotContains( 'foobar', $str );
-
 	}
 
 	function testMenuItemLink() {
@@ -122,15 +131,27 @@ class TimberMenuTest extends WP_UnitTestCase {
 		//$this->assertEquals('/', $item->path() );
 	}
 
-
-	// function testMenuAtLocation(){
-	//  register_nav_menu('theme-menu-location', 'A Nice Place to Put a Menu');
-	//  $menu = $this->_createTestMenu();
-	//  print_r($menu);
-	// }
+	function buildMenu($name, $items) {
+		$menu_term = wp_insert_term( $name, 'nav_menu' );
+		$menu_items = array();
+		$i = 0;
+		foreach($items as $item) {
+			if ($item->type == 'link') {
+				$pid = wp_insert_post(array('post_title' => '', 'post_status' => 'publish', 'post_type' => 'nav_menu_item', 'menu_order' => $i));
+				update_post_meta( $pid, '_menu_item_type', 'custom' );
+				update_post_meta( $pid, '_menu_item_object_id', $pid );
+				update_post_meta( $pid, '_menu_item_url', $item->link );
+				update_post_meta( $pid, '_menu_item_xfn', '' );
+				update_post_meta( $pid, '_menu_item_menu_item_parent', 0 );
+				$menu_items[] = $pid;
+			}
+			$i++;
+		}
+		$this->insertIntoMenu($menu_term['term_id'], $menu_items);
+		return $menu_term;
+	}
 
 	function _createTestMenu() {
-		global $wpdb;
 		$menu_term = wp_insert_term( 'Menu One', 'nav_menu' );
 		$menu_id = $menu_term['term_id'];
 		$menu_items = array();
@@ -253,6 +274,12 @@ class TimberMenuTest extends WP_UnitTestCase {
 		update_post_meta( $link_id, '_menu_item_xfn', '' );
 		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
 
+		$this->insertIntoMenu($menu_id, $menu_items);
+		return $menu_term;
+	}
+
+	function insertIntoMenu($menu_id, $menu_items) {
+		global $wpdb;
 		foreach ( $menu_items as $object_id ) {
 			$query = "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id, term_order) VALUES ($object_id, $menu_id, 0);";
 			$wpdb->query( $query );
@@ -260,8 +287,6 @@ class TimberMenuTest extends WP_UnitTestCase {
 		}
 		$menu_items_count = count( $menu_items );
 		$wpdb->query( "UPDATE $wpdb->term_taxonomy SET count = $menu_items_count WHERE taxonomy = 'nav_menu'; " );
-		$results = $wpdb->get_results( "SELECT * FROM $wpdb->term_taxonomy" );
-		return $menu_term;
 	}
 
 	function setPermalinkStructure( $struc = '/%postname%/' ) {
@@ -317,10 +342,4 @@ class TimberMenuTest extends WP_UnitTestCase {
 
 	}
 
-
-
-
 }
-
-
-

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -2,12 +2,7 @@
 class TimberMenuTest extends WP_UnitTestCase {
 
 	function testBlankMenu() {
-		$struc = '/%postname%/';
-		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure( $struc );
-		$wp_rewrite->flush_rules();
-		update_option( 'permalink_structure', $struc );
-		flush_rewrite_rules( true );
+		$this->setPermalinkStructure();
 		$this->_createTestMenu();
 		$menu = new TimberMenu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
@@ -22,6 +17,10 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'http://example.org/home', $item->url );
 		$this->assertEquals( 'http://example.org/home', $item->link() );
 		$this->assertEquals( '/home', $item->path() );
+	}
+
+	function testTrailingSlashesOrNot() {
+		$this->setPermalinkStructure();
 	}
 
 	function testPagesMenu() {
@@ -47,11 +46,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 	}
 
 	function testMenuTwig() {
-		$struc = '/%postname%/';
-		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure( $struc );
-		$wp_rewrite->flush_rules();
-		update_option( 'permalink_structure', $struc );
+		$this->setPermalinkStructure();
 		$context = Timber::get_context();
 		$this->_createTestMenu();
 		$this->go_to( home_url( '/child-page' ) );
@@ -63,11 +58,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 	}
 
 	function testMenuTwigWithClasses() {
-		$struc = '/%postname%/';
-		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure( $struc );
-		$wp_rewrite->flush_rules();
-		update_option( 'permalink_structure', $struc );
+		$this->setPermalinkStructure();
 		$this->_createTestMenu();
 		$this->go_to( home_url( '/home' ) );
 		$context = Timber::get_context();
@@ -82,8 +73,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 	}
 
 	function testMenuItemLink() {
-		$struc = '/%postname%/';
-		update_option( 'permalink_structure', $struc );
+		$this->setPermalinkStructure();
 		$this->_createTestMenu();
 		$menu = new TimberMenu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
@@ -199,10 +189,6 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$post = new TimberPost( $child_menu_item );
 		$menu_items[] = $child_menu_item;
 
-
-
-
-
 		$root_url_link_id = wp_insert_post(
 			array(
 				'post_title' => 'Root Home',
@@ -283,6 +269,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$wp_rewrite->set_permalink_structure( $struc );
 		$wp_rewrite->flush_rules();
 		update_option( 'permalink_structure', $struc );
+		flush_rewrite_rules( true );
 	}
 
 	function testCustomArchivePage() {


### PR DESCRIPTION
This PR cleans-up menu trailing slash behavior to no longer overrride user/WP defaults. It should solve #426 