### PR TITLE
added a timber_cache_loc filter

### DIFF
--- a/functions/timber-loader.php
+++ b/functions/timber-loader.php
@@ -237,7 +237,7 @@ class TimberLoader {
             Timber::$twig_cache = true;
         }
         if (Timber::$twig_cache) {
-            $twig_cache_loc = TIMBER_LOC . '/cache/twig';
+            $twig_cache_loc = apply_filters( 'timber_cache_loc', TIMBER_LOC . '/cache/twig' );
             if (!file_exists($twig_cache_loc)) {
                 mkdir($twig_cache_loc, 0777, true);
             }


### PR DESCRIPTION
Add a filter that will allow us to change the location of twig cached files.

This way if someone wants to change the default location and store the caches say on wp-content/cache (see #441) or anywhere else they'll be able to do it.