### PR TITLE
added getter for comment_status

### DIFF
--- a/functions/timber-comment.php
+++ b/functions/timber-comment.php
@@ -101,6 +101,13 @@ class TimberComment extends TimberCore implements TimberCoreInterface {
     /**
      * @return string
      */
+    public function status() {
+        return $this->comment_status;
+    }
+
+    /**
+     * @return string
+     */
     public function date() {
         return $this->comment_date;
     }


### PR DESCRIPTION
Currently there is no method to get the comment_status. I could be useful to create a frontend that show all comments:

```html
<tr class="{{ comment.status }}">
    <td>{{ comment.date | date('d.m.y - h:i:s') }} Uhr</td>
    <td>{{ comment.author.name }}</td>
    <td>{{ comment.content }}</td>
</tr> 
```