### PR TITLE
added static get_loader method

### DIFF
--- a/lib/timber-user.php
+++ b/lib/timber-user.php
@@ -182,6 +182,14 @@ class TimberUser extends TimberCore implements TimberCoreInterface {
     function slug() {
         return $this->user_nicename;
     }
+    
+    
+    /**
+     * @return string
+     */
+    function email() {
+        return $this->user_email;
+    }
 
     /**
      * @return string

--- a/timber.php
+++ b/timber.php
@@ -389,6 +389,7 @@ class Timber {
      * @return string
      */
     public static function get_sidebar_from_php($sidebar = '', $data) {
+		$caller = self::get_calling_script_dir();
         $loader = self::get_loader();
         $uris = $loader->get_locations($caller);
         ob_start();

--- a/timber.php
+++ b/timber.php
@@ -277,6 +277,15 @@ class Timber {
         $data = apply_filters('timber_context', $data);
         return $data;
     }
+	
+    /**
+     * @return TimberLoader
+     */
+	public static function get_loader() {
+		$caller = self::get_calling_script_dir();
+		$loader = new TimberLoader($caller);
+		return $loader;
+	}
 
     /**
      * @param array $filenames
@@ -290,7 +299,7 @@ class Timber {
         $caller = self::get_calling_script_dir();
         $caller_file = self::get_calling_script_file();
         $caller_file = apply_filters('timber_calling_php_file', $caller_file);
-        $loader = new TimberLoader($caller);
+        $loader = self::get_loader();
         $file = $loader->choose_template($filenames);
         $output = '';
         if (is_null($data)){
@@ -380,8 +389,7 @@ class Timber {
      * @return string
      */
     public static function get_sidebar_from_php($sidebar = '', $data) {
-        $caller = self::get_calling_script_dir();
-        $loader = new TimberLoader();
+        $loader = self::get_loader();
         $uris = $loader->get_locations($caller);
         ob_start();
         $found = false;


### PR DESCRIPTION
I removed the duplicated code in the "compile" and "get_sidebar_from_php" methods and put it in the "get_loader"-method Also, you are no able to get the loader in your theme to check if a template exists:

```php
    $loader = Timber::get_loader();
    if ($loader->template_exists('my-file.twig')) {
        // ...
    }
```

I think the $caller_file is unused, or am i wrong?