### PR TITLE
Changes visibility to protected on TimberPost::check_post_id()

### DIFF
--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -122,12 +122,12 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 
 
     /**
-     *  helps you find the post id regardless of whetehr you send a string or whatever
+     *  helps you find the post id regardless of whether you send a string or whatever
      *
      * @param integer $pid ;
      * @return integer ID number of a post
      */
-    private function check_post_id($pid) {
+    protected function check_post_id($pid) {
         if (is_numeric($pid) && $pid === 0) {
             $pid = get_the_ID();
             return $pid;


### PR DESCRIPTION
This method is usable for classes extending TImberPost. Setting it as protected still hides it from being called on the instance.