### PR TITLE
Let's allow the timber plugin to load the composer autoload from three different locations

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -11,10 +11,12 @@ Author URI: http://upstatement.com/
 global $wp_version;
 global $timber;
 
-// we look for Composer files first in the theme (theme install)
+// we look for Composer files first in the plugins dir
 // then in the wp-content dir (site install)
-if (    file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' )
-	|| file_exists( $composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php' ) ) {
+// and finally in the current themes directory
+if (   file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' )
+	|| file_exists( $composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php')
+	|| file_exists( $composer_autoload = get_template_directory().'/vendor/autoload.php')) {
 	require_once $composer_autoload;
 }
 


### PR DESCRIPTION
Problem
-----------
In the original implementation, you implement the following logic:
```
// we look for Composer files first in the theme (theme install)
// then in the wp-content dir (site install)
if (    file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' )
	|| file_exists( $composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php' ) ) {
	require_once $composer_autoload;
}
```
The first file exists function does not actually check the themes folder. Instead, it loads from the current file directory and checks to see if a vendor folder is found within it --usually this is done when you require a common composer package. However, the second condition does stay constant to the comment above.

Solution
-----------
Let's stay consistent with the comment above, we do the following checks:
1. In the plugin's directory itself
2. Next we check within the `wp-content` folder
3. Include a check if the vendor folder might be available within the current themes folder.

I think it's important we allow this options as composer installers would allow you to essentially install to these preferable directories. 

This isn't a clean fix, but it does the job. I would suggest we analyze the way [Yoast/wordpress-seo](https://github.com/Yoast/wordpress-seo/blob/trunk/wp-seo-main.php) handles their autoloading. It stays agnostic to whatever implementation you like in conjuction with composer installer package.
