### PR TITLE
properly detect external image using content_url

### DIFF
--- a/lib/timber-image-helper.php
+++ b/lib/timber-image-helper.php
@@ -160,21 +160,6 @@ class TimberImageHelper {
 
 //-- end of public methods --//
 
-
-
-
-    /**
-     * @return boolean true if $path is an external url, false if relative or local.
-     */
-    protected static function is_external($path) {
-        // using content_url() instead of site_url or home_url is IMPORTANT
-        // otherwise you run into errors with sites that:
-        // 1. use WPML plugin
-        // 2. or redefine upload directory
-        $is_external = TimberURLHelper::is_absolute($path) && !strstr($path, content_url());
-        return $is_external;
-    }
-
     /**
      * Deletes resized versions of the supplied file name.
      * So if passed a value like my-pic.jpg, this function will delete my-pic-500x200-c-left.jpg, my-pic-400x400-c-default.jpg, etc.
@@ -421,7 +406,7 @@ class TimberImageHelper {
             return '';
         }
         // if external image, load it first
-        if ( self::is_external( $src ) ) {
+        if ( TimberURLHelper::is_external_content( $src ) ) {
             $src = self::sideload_image( $src );
         }
         // break down URL into components

--- a/lib/timber-image-helper.php
+++ b/lib/timber-image-helper.php
@@ -167,10 +167,11 @@ class TimberImageHelper {
      * @return boolean true if $path is an external url, false if relative or local.
      */
     protected static function is_external($path) {
-        $is_external = TimberURLHelper::is_absolute($path) && !strstr($path, site_url());
-        if ($is_external) {
-            $is_external = TimberURLHelper::is_absolute($path) && !strstr($path, home_url());
-        }
+        // using content_url() instead of site_url or home_url is IMPORTANT
+        // otherwise you run into errors with sites that:
+        // 1. use WPML plugin
+        // 2. or redefine upload directory
+        $is_external = TimberURLHelper::is_absolute($path) && !strstr($path, content_url());
         return $is_external;
     }
 

--- a/lib/timber-url-helper.php
+++ b/lib/timber-url-helper.php
@@ -179,6 +179,22 @@ class TimberURLHelper {
     }
 
     /**
+     * This function is slightly different from the one below in the case of:
+     * an image hosted on the same domain BUT on a different site than the
+     * Wordpress install will be reported as external content.
+     * 
+     * @param  [type]  $url [description]
+     * @return boolean      if $url points to 
+     */
+    public static function is_external_content($url) {
+        // using content_url() instead of site_url or home_url is IMPORTANT
+        // otherwise you run into errors with sites that:
+        // 1. use WPML plugin
+        // 2. or redefine upload directory
+        $is_external = TimberURLHelper::is_absolute($path) && !strstr($path, content_url());
+    }
+
+    /**
      * @param string $url
      * @return bool     true if $path is an external url, false if relative or local.
      *                  true if it's a subdomain (http://cdn.example.org = true)

--- a/lib/timber-url-helper.php
+++ b/lib/timber-url-helper.php
@@ -191,7 +191,7 @@ class TimberURLHelper {
         // otherwise you run into errors with sites that:
         // 1. use WPML plugin
         // 2. or redefine upload directory
-        $is_external = TimberURLHelper::is_absolute($path) && !strstr($path, content_url());
+        $is_external = TimberURLHelper::is_absolute($url) && !strstr($url, content_url());
     }
 
     /**


### PR DESCRIPTION
Hi,

The TimberImageHelper::is_external did not handle the case where upload_dir was overridden.
This PR fixes it.

In addition, I moved the function itself to TimberURLHelper::is_external_content($url).