### PR TITLE
Passing ID thru to 'timber_image_src' filter

### DIFF
--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -113,8 +113,8 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 		$base = ($dir["baseurl"]);
 
 		$src = trailingslashit($this->_maybe_secure_url($base)) . $this->file;
-		$src = apply_filters('timber/image/src', $src);
-		return apply_filters('timber_image_src', $src);
+		$src = apply_filters('timber/image/src', $src, $this->ID);
+		return apply_filters('timber_image_src', $src, $this->ID);
 	}
 
 	private static function _maybe_secure_url($url) {


### PR DESCRIPTION
We're using [WP Offload S3](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to serve images through S3/CloudFront, and it works most of its magic through hooks in `wp_get_attachment_url()`. Since Timber never calls this function, we're currently using the timber_image_src hook to rewrite the URL string, but that's not super robust.

Passing the ID through as an arg to this filter makes compatibility super simple. Does this seem like a sensible addition? Alternately, any thoughts on a better way to do this?