### PR TITLE
Fix for Timber ignoring default_comments_page and missing pages in comment pagination

### DIFF
--- a/lib/timber-helper.php
+++ b/lib/timber-helper.php
@@ -172,13 +172,13 @@ class TimberHelper {
 	 * @param string  $allowed_tags
 	 * @return string
 	 */
-	public static function trim_words( $text, $num_words = 55, $more = null, $allowed_tags = 'p a span b i br' ) {
+	public static function trim_words( $text, $num_words = 55, $more = null, $allowed_tags = 'p a span b i br blockquote' ) {
 		if ( null === $more ) {
 			$more = __( '&hellip;' );
 		}
 		$original_text = $text;
 		$allowed_tag_string = '';
-		foreach ( explode( ' ', $allowed_tags ) as $tag ) {
+		foreach ( explode( ' ', apply_filters( 'timber_trim_words_allowed_tags', $allowed_tags ) ) as $tag ) {
 			$allowed_tag_string .= '<' . $tag . '>';
 		}
 		$text = strip_tags( $text, $allowed_tag_string );

--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -554,6 +554,8 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * @return mixed
 	 */
 	function get_comments($ct = 0, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'TimberComment') {
+		global $overridden_cpage;
+
 		$args = array('post_id' => $this->ID, 'status' => $status, 'order' => $order);
 		if ($ct > 0) {
 			$args['number'] = $ct;
@@ -564,6 +566,12 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 
         $comments = get_comments($args);
         $tComments = array();
+
+		$overridden_cpage = false;
+		if ( '' == get_query_var('cpage') && get_option('page_comments') ) {
+			set_query_var( 'cpage', 'newest' == get_option('default_comments_page') ? get_comment_pages_count() : 1 );
+			$overridden_cpage = true;
+		}
 
         foreach($comments as $key => &$comment) {
             $tComment = new $CommentClass($comment);


### PR DESCRIPTION
Hi,

This is a piece of code from WP core (`comments_template()`) required for Timber to respect properly the default_comments_page setting from the Discussion settings in WP. Without this comments pagination will be broken, missing comments pages can happen (I was getting only 2 pages instead of 3) and first comments would be displayed not accordingly to what's saved in the Discussion settings.

Cheers

P.S Contains my other pull request to add `blockquote` to allowed_tags in `trim_words` and possibility of filtering the `$allowed_tags`