### PR TITLE
Remove constant usages from TimberTheme

### DIFF
--- a/lib/timber-theme.php
+++ b/lib/timber-theme.php
@@ -88,7 +88,7 @@ class TimberTheme extends TimberCore {
 		$ss = $data->get_stylesheet();
 		$this->slug = $ss;
 
-		if ( !function_exists('get_home_path') ) {
+		if ( ! function_exists( 'get_home_path' ) ) {
 			require_once(ABSPATH . 'wp-admin/includes/file.php');
 		}
 

--- a/lib/timber-theme.php
+++ b/lib/timber-theme.php
@@ -87,13 +87,13 @@ class TimberTheme extends TimberCore {
 		$this->name = $data->get('Name');
 		$ss = $data->get_stylesheet();
 		$this->slug = $ss;
-        
-        if(!function_exists('get_home_path')) {
-            require_once(ABSPATH . 'wp-admin/includes/file.php');
-        }
-        
+
+	if(!function_exists('get_home_path')) {
+		require_once(ABSPATH . 'wp-admin/includes/file.php');
+	}
+
 		$this->path = str_replace(get_home_path(), '/', get_stylesheet_directory());
-        
+
 		$this->uri = get_stylesheet_directory_uri();
 		$this->link = $this->uri;
 		$this->parent_slug = $data->get('Template');

--- a/lib/timber-theme.php
+++ b/lib/timber-theme.php
@@ -87,12 +87,18 @@ class TimberTheme extends TimberCore {
 		$this->name = $data->get('Name');
 		$ss = $data->get_stylesheet();
 		$this->slug = $ss;
-		$this->path = WP_CONTENT_SUBDIR . str_replace(WP_CONTENT_DIR, '', get_stylesheet_directory());
+        
+        if(!function_exists('get_home_path')) {
+            require_once(ABSPATH . 'wp-admin/includes/file.php');
+        }
+        
+		$this->path = str_replace(get_home_path(), '/', get_stylesheet_directory());
+        
 		$this->uri = get_stylesheet_directory_uri();
 		$this->link = $this->uri;
 		$this->parent_slug = $data->get('Template');
 		if (!$this->parent_slug) {
-			$this->path = WP_CONTENT_SUBDIR . str_replace(WP_CONTENT_DIR, '', get_template_directory());
+			$this->path = str_replace(get_home_path(), '/', get_template_directory());
 			$this->uri = get_template_directory_uri();
 		}
 		if ($this->parent_slug && $this->parent_slug != $this->slug) {

--- a/lib/timber-theme.php
+++ b/lib/timber-theme.php
@@ -88,20 +88,20 @@ class TimberTheme extends TimberCore {
 		$ss = $data->get_stylesheet();
 		$this->slug = $ss;
 
-	if(!function_exists('get_home_path')) {
-		require_once(ABSPATH . 'wp-admin/includes/file.php');
-	}
+		if ( !function_exists('get_home_path') ) {
+			require_once(ABSPATH . 'wp-admin/includes/file.php');
+		}
 
 		$this->path = str_replace(get_home_path(), '/', get_stylesheet_directory());
 
 		$this->uri = get_stylesheet_directory_uri();
 		$this->link = $this->uri;
 		$this->parent_slug = $data->get('Template');
-		if (!$this->parent_slug) {
+		if ( !$this->parent_slug ) {
 			$this->path = str_replace(get_home_path(), '/', get_template_directory());
 			$this->uri = get_template_directory_uri();
 		}
-		if ($this->parent_slug && $this->parent_slug != $this->slug) {
+		if ( $this->parent_slug && $this->parent_slug != $this->slug ) {
 			$this->parent = new TimberTheme($this->parent_slug);
 		}
 	}

--- a/lib/timber-url-helper.php
+++ b/lib/timber-url-helper.php
@@ -225,14 +225,26 @@ class TimberURLHelper {
 	 * @return boolean if $url points to an external location returns true
 	 */
 	public static function is_external_content( $url ) {
-		// using content_url() instead of site_url or home_url is IMPORTANT
-		// otherwise you run into errors with sites that:
-		// 1. use WPML plugin
-		// 2. or redefine upload directory
-		$is_external = TimberURLHelper::is_absolute( $url ) && !strstr( $url, content_url() );
+		$is_external = TimberURLHelper::is_absolute( $url ) && !TimberURLHelper::is_internal_content($url);
+                
 		return $is_external;
 	}
 
+    private static function is_internal_content($url) {
+        // using content_url() instead of site_url or home_url is IMPORTANT
+		// otherwise you run into errors with sites that:
+		// 1. use WPML plugin
+		// 2. or redefine content directory
+		$is_content_url = strstr( $url, content_url());
+        
+        // this case covers when the upload directory has been redefined
+        $upload_dir = wp_upload_dir();
+        $is_upload_url = strstr( $url, $upload_dir['baseurl']);
+        
+        return $is_content_url || $is_upload_url;
+    }
+    
+    
 	/**
 	 *
 	 *

--- a/lib/timber-url-helper.php
+++ b/lib/timber-url-helper.php
@@ -225,25 +225,24 @@ class TimberURLHelper {
 	 * @return boolean if $url points to an external location returns true
 	 */
 	public static function is_external_content( $url ) {
-		$is_external = TimberURLHelper::is_absolute( $url ) && !TimberURLHelper::is_internal_content($url);
-                
+		$is_external = TimberURLHelper::is_absolute( $url ) && ! TimberURLHelper::is_internal_content( $url );
+
 		return $is_external;
 	}
 
-    private static function is_internal_content($url) {
-        // using content_url() instead of site_url or home_url is IMPORTANT
+	private static function is_internal_content($url) {
+		// using content_url() instead of site_url or home_url is IMPORTANT
 		// otherwise you run into errors with sites that:
 		// 1. use WPML plugin
 		// 2. or redefine content directory
-		$is_content_url = strstr( $url, content_url());
-        
-        // this case covers when the upload directory has been redefined
-        $upload_dir = wp_upload_dir();
-        $is_upload_url = strstr( $url, $upload_dir['baseurl']);
-        
-        return $is_content_url || $is_upload_url;
-    }
-    
+		$is_content_url = strstr( $url, content_url() );
+
+		// this case covers when the upload directory has been redefined
+		$upload_dir = wp_upload_dir();
+		$is_upload_url = strstr( $url, $upload_dir['baseurl'] );
+
+		return $is_content_url || $is_upload_url;
+	}
     
 	/**
 	 *


### PR DESCRIPTION
According to WordPress documentation, path-related constants shouldn't be used by plugin/themes, and it seems the issue was because Timber was assuming the themes folder would always be inside WP_CONTENT_DIR.

By using methods instead of the constants, `{{theme.path}}` returns the right value.

This should fix `PauGNU`'s issue in #619 