### PR TITLE
Check for jpeg before assuming it's a PNG

### DIFF
--- a/lib/image/timber-image-operation-tojpg.php
+++ b/lib/image/timber-image-operation-tojpg.php
@@ -61,6 +61,11 @@ class TimberImageOperationToJpg extends TimberImageOperation {
 		if ( $ext == 'gif' ) {
 			return imagecreatefromgif($filename);
 		}
-		return imagecreatefrompng($filename);
+		if ( $ext == 'png' ) {
+			return imagecreatefrompng($filename);
+		}
+		if ( ($ext == 'jpeg') || ($ext == 'jpg') ) {
+			return imagecreatefromjpeg($filename);
+		}
 	}
 }


### PR DESCRIPTION
As per #722 this seems to fix the problem of big white images when you pass an image ending with 'JPEG' through the tojpg filter.