### PR TITLE
Fix for the ACF date field issue #724

### DIFF
--- a/lib/timber-twig.php
+++ b/lib/timber-twig.php
@@ -266,7 +266,7 @@ class TimberTwig {
 
 		if ( $date instanceof DateTime ) {
 			$timestamp = $date->getTimestamp();
-		} else if (is_numeric( $date ) ) {
+		} else if (is_numeric( $date ) && strtotime( $date ) === false ) {
 			$timestamp = intval( $date );
 		} else {
 			$timestamp = strtotime( $date );


### PR DESCRIPTION
Add a second condition to check if the $date variable contains a unix timestamp. If a unix timestamp is present strtotime returns false. if you have a date formated by acf strtotime returns the unix timestamp.