### PR TITLE
Allow date formats like '20151029'

### DIFF
--- a/lib/timber-twig.php
+++ b/lib/timber-twig.php
@@ -266,7 +266,7 @@ class TimberTwig {
 
 		if ( $date instanceof DateTime ) {
 			$timestamp = $date->getTimestamp();
-		} else if (is_numeric( $date ) ) {
+		} else if ( is_numeric( $date ) && !strtotime( $date ) ) {
 			$timestamp = intval( $date );
 		} else {
 			$timestamp = strtotime( $date );


### PR DESCRIPTION
Allow numeric values that can be parsed with strtotime (like `20151029') to be used.