### PR TITLE
use WP_Image_Editor() quality for letterbox quality

### DIFF
--- a/lib/image/timber-image-operation-letterbox.php
+++ b/lib/image/timber-image-operation-letterbox.php
@@ -57,6 +57,7 @@ class TimberImageOperationLetterbox extends TimberImageOperation {
 		$image = wp_get_image_editor( $load_filename );
 		if ( !is_wp_error( $image ) ) {
 			$current_size = $image->get_size();
+			$quality = $image->get_quality();
 			$ow = $current_size['width'];
 			$oh = $current_size['height'];
 			$new_aspect = $w / $h;
@@ -87,7 +88,7 @@ class TimberImageOperationLetterbox extends TimberImageOperation {
 			}
 			$image = $func( $save_filename );
 			imagecopy( $bg, $image, $x, $y, 0, 0, $owt, $oht );
-			imagejpeg( $bg, $save_filename );
+			imagejpeg( $bg, $save_filename, $quality );
 			return true;
 		} else {
 			TimberHelper::error_log( $image );


### PR DESCRIPTION
Get's the quality from WP_Image_Editor() and uses that in imagejpeg. Means quality can be controlled with jpeg_quality filter.

In response to https://github.com/jarednova/timber/issues/693.