### PR TITLE
Change action hook 'delete_attachment'

### DIFF
--- a/lib/timber-image-helper.php
+++ b/lib/timber-image-helper.php
@@ -159,14 +159,16 @@ class TimberImageHelper {
 	 * Deletes all resized versions of an image when the source is deleted
 	 */
 	protected static function add_actions() {
-		add_action( 'delete_post', function ( $post_id ) {
-				$post = get_post( $post_id );
-				$image_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/jpg' );
-				if ( $post->post_type == 'attachment' && in_array( $post->post_mime_type, $image_types ) ) {
-					$attachment = new TimberImage( $post_id );
+		add_action( 'delete_attachment', function ( $post_id ) {
+			$post = get_post( $post_id );
+			$image_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/jpg' );
+			if ( in_array( $post->post_mime_type, $image_types ) ) {
+				$attachment = new TimberImage( $post_id );
+				if ( $attachment->file_loc ) {
 					TimberImageHelper::delete_generated_files( $attachment->file_loc );
 				}
-			} );
+			}
+		} );
 	}
 
 	/**


### PR DESCRIPTION
The description of the hook `delete_post` in the WordPress Codex:

> `delete_post` is fired before and after a post (or page) is deleted from the database.
> However by this time the post comments and metadata have been already deleted. Use the `before_delete_post` hook to catch post deletion before that.

When I want to delete all associated attachments together with a post, I would use something like this in my functions.php

```php
add_action( 'before_delete_post', function ( $post_id ) {

	global $post_type;

	if ($post_type !== 'mycustomposttype') {
	    return;
	}

	$attachments = get_children( array(
	    'post_parent' => $post_id,
	    'post_type'   => 'attachment'
	) );

	if ( empty($attachments) ) {
	    return;
	}

	foreach ( $attachments as $attachment ) {
	    wp_delete_attachment($attachment->ID);
	}
});
```

If I would use the `delete_post` hook for that, it wouldn’t work, because the relation between the post and the attachments would already have been deleted, `$attachments` would be empty and no attachments would be deleted, although they would still exist.

The action `delete_attachment` triggers before post meta data is deleted and would also catch cases like the one described above.

The check for the attachment post type (`if ( $post->post_type == 'attachment' )`) would also become obsolete, because `delete_attachment` triggers only on attachment post types.

**Other changes**
- Add check for existing `file_loc` before trying to delete files for that attachment (fix for #676)
- Fix indentation for action function body