### PR TITLE
Fix for "Method TimberFunctionWrapper::__toString() must not throw an…

### DIFF
--- a/lib/timber-function-wrapper.php
+++ b/lib/timber-function-wrapper.php
@@ -7,7 +7,11 @@ class TimberFunctionWrapper {
 	private $_use_ob;
 
 	public function __toString() {
-		return (string)$this->call();
+		try {
+			return (string)$this->call();
+		} catch (Exception $e) {
+			return 'Caught exception: ' . $e->getMessage() . "\n";
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fix for "Method TimberFunctionWrapper::__toString() must not throw an exception"

From time to time we get stopped by this error while working with Gantry and we need to manually change the code to see where the real issue lies - that's why I created this PR ;)

https://monosnap.com/file/FAxian75O4yVcfbR8BG84CxhhvE8Py.png