### PR TITLE
Move class Timber into separate file

### DIFF
--- a/lib/timber.php
+++ b/lib/timber.php
@@ -54,7 +54,7 @@ class Timber {
 	}
 
 	function init_constants() {
-		defined( "TIMBER_LOC" ) or define( "TIMBER_LOC", realpath( __DIR__ ) );
+		defined( "TIMBER_LOC" ) or define( "TIMBER_LOC", realpath( dirname(__DIR__) ) );
 	}
 
 	/**

--- a/lib/timber.php
+++ b/lib/timber.php
@@ -1,30 +1,4 @@
 <?php
-/*
-Plugin Name: Timber
-Description: The WordPress Timber Library allows you to write themes using the power Twig templates.
-Plugin URI: http://timber.upstatement.com
-Author: Jared Novack + Upstatement
-Version: 0.22.5
-Author URI: http://upstatement.com/
-*/
-
-global $wp_version;
-global $timber;
-
-// we look for Composer files first in the plugins dir.
-// then in the wp-content dir (site install).
-// and finally in the current themes directories.
-if (   file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' ) /* check in self */
-	|| file_exists( $composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php') /* check in wp-content */
-	|| file_exists( $composer_autoload = plugin_dir_path( __FILE__ ).'vendor/autoload.php') /* check in plugin directory */
-	|| file_exists( $composer_autoload = get_stylesheet_directory().'/vendor/autoload.php') /* check in child theme */
-	|| file_exists( $composer_autoload = get_template_directory().'/vendor/autoload.php') /* check in parent theme */
-	) {
-	require_once $composer_autoload;
-}
-
-$timber = new Timber();
-Timber::$dirname = 'views';
 
 /**
  * Timber Class.

--- a/timber.php
+++ b/timber.php
@@ -1,0 +1,27 @@
+<?php
+/*
+Plugin Name: Timber
+Description: The WordPress Timber Library allows you to write themes using the power Twig templates.
+Plugin URI: http://timber.upstatement.com
+Author: Jared Novack + Upstatement
+Version: 0.22.5
+Author URI: http://upstatement.com/
+*/
+
+global $wp_version;
+global $timber;
+
+// we look for Composer files first in the plugins dir.
+// then in the wp-content dir (site install).
+// and finally in the current themes directories.
+if (   file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' ) /* check in self */
+    || file_exists( $composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php') /* check in wp-content */
+    || file_exists( $composer_autoload = plugin_dir_path( __FILE__ ).'vendor/autoload.php') /* check in plugin directory */
+    || file_exists( $composer_autoload = get_stylesheet_directory().'/vendor/autoload.php') /* check in child theme */
+    || file_exists( $composer_autoload = get_template_directory().'/vendor/autoload.php') /* check in parent theme */
+) {
+    require_once $composer_autoload;
+}
+
+$timber = new Timber();
+Timber::$dirname = 'views';


### PR DESCRIPTION
- Moved class Timber to lib/timber.php …
- Removed autloading and WP meta data from the class file
- Readded the WordPress plugin file with original content (autloading, instantiation for Timber object)

This PR fixes  issue #833 