### PR TITLE
Add id as a duplicate of ID in timber-image.php

### DIFF
--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -230,6 +230,7 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 			foreach ($custom as $key => $value) {
 				$this->$key = $value[0];
 			}
+			$this->id = $this->ID;
 		} else {
 			if ( is_array($iid) || is_object($iid) ) {
 				TimberHelper::error_log('Not able to init in TimberImage with iid=');


### PR DESCRIPTION
In a TimberPost, you can access the id [through `post.id` or `post.ID`](https://github.com/jarednova/timber/blob/master/lib/timber-post.php#L628). However with a `post.thumbnail`, you can only use `post.thumbnail.ID`, which doesn't seem intuitive and leads to errors.

This adds `id` to `post.thumbnail` as a duplicate of `ID`.