### PR TITLE
Allow post object as parameter of TimberImage()

### DIFF
--- a/docs/wiki/cookbook-images.md
+++ b/docs/wiki/cookbook-images.md
@@ -85,7 +85,7 @@ This can be used in conjunction with other filters, so for example:
 #### Using images in custom fields:
 Let's say you're using a custom field plugin (like the amazing [Advanced Custom Fields](http://www.advancedcustomfields.com/)). You can use the resulting images in your Twig templates very easily.
 
-When setting up your custom fields you'll want to save the `image_id` to the field. The image object, url, etc. _will_ work but it's not as fool-proof.
+When setting up your custom fields you'll want to save the `image_id` to the field. The image object, post object, url, etc. _will_ work but it's not as fool-proof.
 
 ##### The quick way (for most situations)
 
@@ -108,7 +108,7 @@ $data['post'] = $post;
 Timber::render('single.twig', $data);
 ```
 
-`TimberImage` should be initialized using a WordPress image ID#. It can also take URLs and image objects, but that requires extra processing.
+`TimberImage` should be initialized using a WordPress image ID#. It can also take URLs, image objects and post objects, but that requires extra processing.
 
 You can now use all the above functions to transform your custom images in the same way, the format will be:
 

--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -207,6 +207,11 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 				$this->init_with_relative_path($iid);
 				return;
 			}
+		} else if ( $iid instanceof WP_Post ) {
+			$ref = new ReflectionClass($this);
+			$post = $ref->getParentClass()->newInstance($iid->ID);
+		
+			return $this->init((int) $post->_thumbnail_id);
 		}
 
 		$image_info = $this->get_image_info($iid);

--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -212,6 +212,13 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 			$post = $ref->getParentClass()->newInstance($iid->ID);
 		
 			return $this->init((int) $post->_thumbnail_id);
+		} else if ( $iid instanceof TimberPost ) {
+			/**
+			 * This will catch TimberPost and any post classes that extend TimberPost,
+			 * see http://php.net/manual/en/internals2.opcodes.instanceof.php#109108
+			 * and https://github.com/jarednova/timber/wiki/Extending-Timber
+			 */
+			$iid = (int) $iid->_thumbnail_id;
 		}
 
 		$image_info = $this->get_image_info($iid);


### PR DESCRIPTION
Caveat: I have only just started using Timber so this may already be solvable easily.

**Issue**

Using ACF, if you have a repeater field that contains a relationship field, there is no easy way to get the featured image of the post that has been selected in the relationship field. You can init a new ```TimberPost``` however that is adding more logic to the views whilst it can be easily solved within the ```TimberImage``` class

**Solution**

If you pass a post object to ```TimberImage```, it will grab a new instance of ```TimberPost```, get the ```_thumbnail_id``` and re-init ```TimberImage``` with the correct id.

**Impact**

This will be slightly slower than just passing the ID, but in the instance I described above the only way to do this in the first place is this method, it's just moved the logic away from the view. I haven't benchmarked this change.

**Usage**

```<img src="{{ TimberImage(post.team_members.0) }}" />```

**Considerations**

We may not _want_ TimberImage to be so flexible to reduce chances of bugs, however we already allow other formats than ID's to be passed to ```TimberImage```, so it seems to me a natural progression to allow post objects.