### PR TITLE
Adding support for more relative image types

### DIFF
--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -51,6 +51,10 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 	 */
 	public static $representation = 'image';
 	/**
+	 * @var array of supported relative file types
+	 */
+	private $file_types = array('jpg', 'jpeg', 'png', 'svg', 'bmp', 'ico', 'gif', 'tiff', 'pdf');
+	/**
 	 * @api
 	 * @var string $file_loc the location of the image file in the filesystem (ex: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
 	 */
@@ -203,8 +207,12 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 				$this->init_with_file_path($iid);
 				return;
 			}
-			if ( strstr(strtolower($iid), '.jpg') ) {
-				$this->init_with_relative_path($iid);
+			
+			$relative = false;
+			$iid_lower = strtolower($iid);
+			foreach( $this->file_types as $type ) { if( strstr( $iid_lower, $type ) ) { $relative = true; break; } };
+			if ( $relative ) {
+				$this->init_with_relative_path( $iid );
 				return;
 			}
 		}


### PR DESCRIPTION
**Issue**

If you have static images that you want to use via ```TimberImage('wp-content/themes/default/hello.jpg')``` it will only support ```.jpg```

**Solution**

Adds a ```private``` variable to the class that lists all image types from https://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support and loops over that array to see if any of them exist in the string given.

**Impact**

Negligibly slower

**Usage**

No change

**Considerations**

This version of ```TimberImage``` could do with a little bit more development, currently you would have to hardcode the path to the theme, which isn't great. I tried to add a second parameter ```TimberImage(string, boolean)``` that a user could set to ```true``` to indicate they want a relative path to the theme directory. However it conflicts with the second parameter in ```timber-twig.php:115``` and it wouldn't be very user friendly to do ```TimberImage('images/some-image.jpg, '', true)```