### PR TITLE
Adding request.get/post to TimberSite

### DIFF
--- a/lib/timber-request.php
+++ b/lib/timber-request.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * TimberRequest exposes $_GET and $_POST to the context
+ */
+class TimberRequest extends TimberCore implements TimberCoreInterface {
+
+	$post = array();
+	$get = array();
+	
+	/**
+	 * Constructs a TimberRequest object
+	 * @example
+	 */
+	function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * @internal
+	 */
+	protected function init() {
+		$this->post = $_POST;
+		$this->get = $_GET;
+	}
+}

--- a/lib/timber-request.php
+++ b/lib/timber-request.php
@@ -1,10 +1,8 @@
 <?php
-
 /**
  * TimberRequest exposes $_GET and $_POST to the context
  */
 class TimberRequest extends TimberCore implements TimberCoreInterface {
-
 	public $post = array();
 	public $get = array();
 	
@@ -15,7 +13,6 @@ class TimberRequest extends TimberCore implements TimberCoreInterface {
 	function __construct() {
 		$this->init();
 	}
-
 	/**
 	 * @internal
 	 */
@@ -23,4 +20,15 @@ class TimberRequest extends TimberCore implements TimberCoreInterface {
 		$this->post = $_POST;
 		$this->get = $_GET;
 	}
+
+	public function __call( $field, $args ) {}
+
+	public function __get( $field ) {}
+
+	/**
+	 * @return boolean
+	 */
+	public function __isset( $field ) {}
+
+	public function meta( $key ) {}
 }

--- a/lib/timber-request.php
+++ b/lib/timber-request.php
@@ -5,8 +5,8 @@
  */
 class TimberRequest extends TimberCore implements TimberCoreInterface {
 
-	$post = array();
-	$get = array();
+	public $post = array();
+	public $get = array();
 	
 	/**
 	 * Constructs a TimberRequest object

--- a/lib/timber-site.php
+++ b/lib/timber-site.php
@@ -88,6 +88,8 @@ class TimberSite extends TimberCore implements TimberCoreInterface {
 	public $rss;
 	public $rss2;
 	public $atom;
+	
+	public $request = array('get' => array(), 'post' => array());
 
 	/**
 	 * Constructs a TimberSite object
@@ -166,6 +168,8 @@ class TimberSite extends TimberCore implements TimberCoreInterface {
 		$this->language_attributes = TimberHelper::function_wrapper( 'language_attributes' );
 		/* deprecated benath this comment */
 		$this->pingback_url = get_bloginfo( 'pingback_url' );
+		$this->request['get'] = $_GET;
+		$this->request['post'] = $_POST;
 	}
 
 	/**

--- a/lib/timber-site.php
+++ b/lib/timber-site.php
@@ -89,8 +89,6 @@ class TimberSite extends TimberCore implements TimberCoreInterface {
 	public $rss2;
 	public $atom;
 	
-	public $request = array('get' => array(), 'post' => array());
-
 	/**
 	 * Constructs a TimberSite object
 	 * @example
@@ -168,8 +166,6 @@ class TimberSite extends TimberCore implements TimberCoreInterface {
 		$this->language_attributes = TimberHelper::function_wrapper( 'language_attributes' );
 		/* deprecated benath this comment */
 		$this->pingback_url = get_bloginfo( 'pingback_url' );
-		$this->request['get'] = $_GET;
-		$this->request['post'] = $_POST;
 	}
 
 	/**

--- a/lib/timber.php
+++ b/lib/timber.php
@@ -251,6 +251,7 @@ class Timber {
 		$data['body_class'] = implode( ' ', get_body_class() );
 
 		$data['site'] = new TimberSite();
+		$data['request'] = new TimberRequest();
 		$data['theme'] = $data['site']->theme;
 		//deprecated, these should be fetched via TimberSite or TimberTheme
 		$data['theme_dir'] = WP_CONTENT_SUBDIR.str_replace( WP_CONTENT_DIR, '', get_stylesheet_directory() );


### PR DESCRIPTION
**Issue**

There is no easy way to access GET/POST variables in the Twig templates

**Solution**

Add ```site.request``` array that contains ```site.request.get``` and ```site.request.post```

Eg.

/vacancies/?salary=30000

```
Requested salary: £{{site.request.get.salary}}
```

```
Requested Salary: £30000
```