### PR TITLE
implementing new crop positions: 'top-center' and 'bottom-center'

### DIFF
--- a/lib/image/timber-image-operation-resize.php
+++ b/lib/image/timber-image-operation-resize.php
@@ -15,13 +15,13 @@ class TimberImageOperationResize extends TimberImageOperation {
 	/**
 	 * @param int    $w    width of new image
 	 * @param int    $h    height of new image
-	 * @param string $crop cropping method, one of: 'default', 'center', 'top', 'bottom', 'left', 'right'.
+	 * @param string $crop cropping method, one of: 'default', 'center', 'top', 'bottom', 'left', 'right', 'top-center', 'bottom-center'.
 	 */
 	function __construct($w, $h, $crop) {
 		$this->w = $w;
 		$this->h = $h;
 		// Sanitize crop position
-		$allowed_crop_positions = array( 'default', 'center', 'top', 'bottom', 'left', 'right' );
+		$allowed_crop_positions = array( 'default', 'center', 'top', 'bottom', 'left', 'right', 'top-center', 'bottom-center' );
 		if ( $crop !== false && !in_array( $crop, $allowed_crop_positions ) ) {
 			$crop = $allowed_crop_positions[0];
 		}
@@ -106,32 +106,49 @@ class TimberImageOperationResize extends TimberImageOperation {
 		$src_x = $src_w / 2 - $src_wt / 2;
 		$src_y = ( $src_h - $src_ht ) / 6;
 		//now specific overrides based on options:
-		if ( $crop == 'center' ) {
-			// Get source x and y
-			$src_x = round( ( $src_w - $src_wt ) / 2 );
-			$src_y = round( ( $src_h - $src_ht ) / 2 );
-		} else if ( $crop == 'top' ) {
-			$src_y = 0;
-		} else if ( $crop == 'bottom' ) {
-			$src_y = $src_h - $src_ht;
-		} else if ( $crop == 'left' ) {
-			$src_x = 0;
-		} else if ( $crop == 'right' ) {
-			$src_x = $src_w - $src_wt;
+		switch ( $crop ) {
+			case 'center':
+				// Get source x and y
+				$src_x = round( ( $src_w - $src_wt ) / 2 );
+				$src_y = round( ( $src_h - $src_ht ) / 2 );
+				break;
+
+			case 'top':
+				$src_y = 0;
+				break;
+
+			case 'bottom':
+				$src_y = $src_h - $src_ht;
+				break;
+
+			case 'top-center':
+				$src_y = round( ( $src_h - $src_ht ) / 4 );
+				break;
+
+			case 'bottom-center':
+				$src_y = $src_h - $src_ht - round( ( $src_h - $src_ht ) / 4 );
+				break;
+
+			case 'left':
+				$src_x = 0;
+				break;
+
+			case 'right':
+				$src_x = $src_w - $src_wt;
+				break;
 		}
 		// Crop the image
-		if ( $dest_ratio > $src_ratio ) {
-			return array(
+		return ( $dest_ratio > $src_ratio )
+			? array(
 				'x' => 0, 'y' => $src_y,
 				'src_w' => $src_w, 'src_h' => $src_ht,
 				'target_w' => $w, 'target_h' => $h
+			)
+			: array(
+				'x' => $src_x, 'y' => 0,
+				'src_w' => $src_wt, 'src_h' => $src_h,
+				'target_w' => $w, 'target_h' => $h
 			);
-		}
-		return array(
-			'x' => $src_x, 'y' => 0,
-			'src_w' => $src_wt, 'src_h' => $src_h,
-			'target_w' => $w, 'target_h' => $h
-		);
 	}
 
 	/**

--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -333,7 +333,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * @param bool $strip Strip tags? yes or no. tell me!
 	 * @return string of the post preview
 	 */
-	function get_preview($len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = ' &hellip;') {
+	function get_preview($len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = '&hellip;') {
 		$text = '';
 		$trimmed = false;
 		if ( isset($this->post_excerpt) && strlen($this->post_excerpt) ) {

--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -331,6 +331,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * @param bool $force What happens if your custom post excerpt is longer then the length requested? By default (`$force = false`) it will use the full `post_excerpt`. However, you can set this to true to *force* your excerpt to be of the desired length
 	 * @param string $readmore The text you want to use on the 'readmore' link
 	 * @param bool $strip Strip tags? yes or no. tell me!
+	 * @param string $end The text to end the preview with (defaults to ...)
 	 * @return string of the post preview
 	 */
 	function get_preview($len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = '&hellip;') {

--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -333,7 +333,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * @param bool $strip Strip tags? yes or no. tell me!
 	 * @return string of the post preview
 	 */
-	function get_preview($len = 50, $force = false, $readmore = 'Read More', $strip = true) {
+	function get_preview($len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = ' &hellip;') {
 		$text = '';
 		$trimmed = false;
 		if ( isset($this->post_excerpt) && strlen($this->post_excerpt) ) {
@@ -367,7 +367,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 			$text = trim($text);
 			$last = $text[strlen($text) - 1];
 			if ( $last != '.' && $trimmed ) {
-				$text .= ' &hellip;';
+				$text .= $end;
 			}
 			if ( !$strip ) {
 				$last_p_tag = strrpos($text, '</p>');
@@ -375,7 +375,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 					$text = substr($text, 0, $last_p_tag);
 				}
 				if ( $last != '.' && $trimmed ) {
-					$text .= ' &hellip; ';
+					$text .= $end . ' ';
 				}
 			}
 			$read_more_class = apply_filters('timber/post/get_preview/read_more_class', "read-more");

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -73,6 +73,28 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$this->assertTrue( $is_teal );
 	}
 
+	function testCropBottomCenter() {
+		$cropper = TestTimberImage::copyTestImage('cropper.png');
+		$resized = TimberImageHelper::resize($cropper, 300, 100, 'bottom-center');
+
+		$resized = str_replace('http://example.org', '', $resized);
+		$resized = TimberUrlHelper::url_to_file_system( $resized );
+
+		$is_teal = TestTimberImage::checkPixel($resized, 200, 50, '#00ffff');
+		$this->assertTrue( $is_teal );
+	}
+
+	function testCropTopCenter() {
+		$cropper = TestTimberImage::copyTestImage('cropper.png');
+		$resized = TimberImageHelper::resize($cropper, 300, 100, 'top-center');
+
+		$resized = str_replace('http://example.org', '', $resized);
+		$resized = TimberUrlHelper::url_to_file_system( $resized );
+
+		$is_red = TestTimberImage::checkPixel($resized, 100, 50, '#ff0000', '#ff0800');
+		$this->assertTrue( $is_red );
+	}
+
 	function testCropHeight() {
 		$arch = TestTimberImage::copyTestImage('arch.jpg');
 		$resized = TimberImageHelper::resize($arch, false, 250);

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -38,7 +38,7 @@
 			// no excerpt
 			$post->post_excerpt = '';
 			$preview = $post->get_preview(3);
-			$this->assertRegExp('/this is super &hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $preview);
+			$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $preview);
 
 			// excerpt set, force is false, no read more
 			$post->post_excerpt = 'this is excerpt longer than three words';
@@ -48,7 +48,7 @@
 			// custom read more set
 			$post->post_excerpt = '';
 			$preview = $post->get_preview(3, false, 'Custom more');
-			$this->assertRegExp('/this is super &hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', $preview);
+			$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', $preview);
 
 			// content with <!--more--> tag, force false
 			$post->post_content = 'this is super dooper<!--more--> trooper long words';
@@ -62,7 +62,7 @@
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [mythang]', 'post_excerpt' => '') );
 			$post = new TimberPost( $pid );
-			$this->assertEquals('jared mythangy &hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
+			$this->assertEquals('jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
 		}
 
 		function testShortcodesInPreviewFromContentWithMoreTag() {
@@ -77,7 +77,7 @@
 		function testPreviewWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = new TimberPost( $pid );
-			$this->assertEquals('Lauren is a &hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true));
+			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true));
 		}
 
 		function testPreviewWithMoreTagAndForcedLength() {

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -92,4 +92,10 @@
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->get_preview());
 		}
 
+		function testPreviewWithCustomEnd() {
+			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck', 'post_excerpt' => '') );
+			$post = new TimberPost( $pid );
+			$this->assertEquals('Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true, 'Read More', true, ' ???'));
+		}
+
 	}


### PR DESCRIPTION
useful when cropping vertical 9:16 images or creating Material Design cards.
I think that the image used in unit tests should be changed before writing new tests for 'top-center' and 'bottom-center' positions

![example](https://cloud.githubusercontent.com/assets/675348/13203275/c4125102-d8c5-11e5-868d-07281f36b5e7.jpg)