### PR TITLE
Adding support for classes in Function Wrapper

### DIFF
--- a/docs/wiki/wp-integration.md
+++ b/docs/wiki/wp-integration.md
@@ -110,7 +110,7 @@ For a less quick-and-dirty way, you can use the TimberFunctionWrapper. This clas
 TimberHelper::function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false );
 ```
 
-Classes (including namespaced) are also support for `function_wrapper`:
+Classes (including namespaced) are also supported for `function_wrapper`:
 
 ```php
 # Namespaced has to be a string

--- a/docs/wiki/wp-integration.md
+++ b/docs/wiki/wp-integration.md
@@ -102,13 +102,25 @@ For a less quick-and-dirty way, you can use the TimberFunctionWrapper. This clas
 
 ```php
 /**
- * @param string $function_name
+ * @param mixed $function_name or array( $class( string|object ), $function_name )
  * @param array (optional) $defaults
  * @param bool (optional) $return_output_buffer Return function output instead of return value (default: false)
  * @return \TimberFunctionWrapper
  */
 TimberHelper::function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false );
 ```
+
+Classes (including namespaced) are also support for `function_wrapper`:
+
+```php
+# Namespaced has to be a string
+TimberHelper::function_wrapper('Example\Class', 'function_in_class');
+
+# Otherwise, you can pass the object of the class
+TimberHelper::function_wrapper($this, 'function_in_class');
+```
+
+You can then call the function like so `{{function_in_class}}`
 
 So if you want to add `edit_post_link` to your context, you can do something like this:
 

--- a/lib/timber-function-wrapper.php
+++ b/lib/timber-function-wrapper.php
@@ -2,6 +2,7 @@
 
 class TimberFunctionWrapper {
 
+	private $_class;
 	private $_function;
 	private $_args;
 	private $_use_ob;
@@ -22,7 +23,16 @@ class TimberFunctionWrapper {
 	 * @param bool    $return_output_buffer
 	 */
 	public function __construct( $function, $args = array(), $return_output_buffer = false ) {
-		$this->_function = $function;
+		if( is_array( $function ) ) {
+			if( (is_string( $function[0] ) && class_exists( $function[0] ) ) || gettype( $function[0] ) === 'object' ) {
+				$this->_class = $function[0];
+			}
+			
+			if( is_string( $function[1] ) ) $this->_function = $function[1];
+		} else {
+			$this->_function = $function;
+		}
+
 		$this->_args = $args;
 		$this->_use_ob = $return_output_buffer;
 
@@ -52,11 +62,12 @@ class TimberFunctionWrapper {
 	 */
 	public function call() {
 		$args = $this->_parse_args( func_get_args(), $this->_args );
+		$callable = ( isset( $this->_class ) ) ? array( $this->_class, $this->_function ) : $this->_function;
 
 		if ( $this->_use_ob ) {
-			return TimberHelper::ob_function( $this->_function, $args );
+			return TimberHelper::ob_function( $callable, $args );
 		} else {
-			return call_user_func_array( $this->_function, $args );
+			return call_user_func_array( $callable, $args );
 		}
 	}
 

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -20,6 +20,15 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 		$this->assertEquals(1, $content);
 	}
 
+	function testToStringWithClassObject() {
+		ob_start();
+		$wrapper = new TimberFunctionWrapper(array($this, 'isNum'), array(4));
+		echo $wrapper;
+		$content = trim(ob_get_contents());
+		ob_end_clean();
+		$this->assetEquals(1, $content);
+	}
+
 	/* Sample function to test exception handling */
 
 	static function isNum($num) {

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -26,7 +26,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 		echo $wrapper;
 		$content = trim(ob_get_contents());
 		ob_end_clean();
-		$this->assetEquals(1, $content);
+		$this->assertEquals(1, $content);
 	}
 
 	/* Sample function to test exception handling */


### PR DESCRIPTION
Adds official (you can currently do `TimberFunctionWrapper('MyClass::staticFunction')`) support for classes in `TimberFunctionWrapper`. Fixes #854 and #843

**Issue**

It's currently not documented that you can do `TimberFunctionWrapper('MyClass::staticFunction')` and also that does not solve the issue with non static functions.

**Solution**

Allows the first parameter of `TimberFunctionWrapper` to be an array, consisting of an `object` (class) OR a `string` that references a class. It seems you need to pass a string for name spaced classes `TimberFunctionWrapper(array('MyNamespaces\Container', 'some_function'))`, however you can also pass a class `object` as the first parameter of the array.

**Impact**

Negligibly slower.

**Usage**

`TimberFunctionWrapper(array($classObject, 'function_name'))`
`TimberFunctionWrapper(array('MyNamespace\Container', 'function_name'))`

**Considerations**

I have only added 1 extra test (haven't ran the test either), we may need to create a dummy namespaced class for testing the namespace version of this? Input on how to handle this best would be great.

Also I am wondering if we can get away from `call_user_func_array` as it's super slow.