### PR TITLE
Lowercasing extensions of externally reszied images

### DIFF
--- a/lib/timber-image-helper.php
+++ b/lib/timber-image-helper.php
@@ -430,9 +430,12 @@ class TimberImageHelper {
 		if ( empty( $src ) ) {
 			return '';
 		}
+		$external = false;
+
 		// if external image, load it first
 		if ( TimberURLHelper::is_external_content( $src ) ) {
 			$src = self::sideload_image( $src );
+			$external = true;
 		}
 		// break down URL into components
 		$au = self::analyze_url($src);
@@ -465,6 +468,9 @@ class TimberImageHelper {
 		}
 		// otherwise generate result file
 		if($op->run($old_server_path, $new_server_path)) {
+			if( get_class( $op ) === 'TimberImageOperationResize' && $external ) {
+				$new_url = strtolower( $new_url );
+			}
 			return $new_url;
 		} else {
 			// in case of error, we return source file itself


### PR DESCRIPTION
Fixes #829 

**Issue**

If you do something like `{{TimberImage('http://website.com/my-external-image.JPG')|resize(400, 200)}}` it will generate a new file with the extension lowercased, however it will return the original case of the extension. For example `42123710cb0cd8c9edba9ca4b6210f72-300x600-c-default.JPG` even though the file is `42123710cb0cd8c9edba9ca4b6210f72-300x600-c-default.jpg`

**Solution**

It's a very simple solution, and something that I think should be updated further down the road. It keeps track of if an image is external in `$external`, then checks if it has gone through a resize operation, if both are true `strtolower`s the whole string.

The other thing to consider is, we can't just blanket `strtolower` any external images, as if it isn't resized it will reference the image directly rather than saving a copy.

**Impact**

Negligibly slower.

**Usage**

No change

**Considerations**

I really don't like how I have done the fix, however it works for now. What would be better is to have an image object here rather than just the URL, we can then have an `external` property.