### PR TITLE
ref #870 -- added issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Expected behavior
+<!-- Please describe what output you expect to see from Timber -->
+
+### Actual behavior
+<!-- Please describe what you see instead. Please provide samples of HTML output or screenshots -->
+
+### Steps to reproduce behavior
+<!-- Please include complete code samples in-line or linked from [gists](https://gist.github.com/) -->
+
+### What version of WordPress, PHP and Timber are you using?
+<!-- Example: WordPress 4.4.1, PHP 5.4, Timber 0.22.5 -->
+
+### How did you install Timber? (for example, from GitHub, Composer/Packagist, WP.org?)
+<!-- Example: Upgraded to newest version via plugin updater in WordPress dashboard -->


### PR DESCRIPTION
This solves #870 by adding a template for issues.

#### Issue
Lots of random support queries were coming into GitHub, which should instead be directed to StackOverflow. Even "good" issues w actual bugs would come in without clear details and ways to reproduce

#### Solution
Use GitHub's new issue templates to provide issue-filers with guidelines and a format

#### Impact
None, just an extra file in the repo

#### Usage
No change

#### Considerations
This should lead to a matching PR template; for which I love this format that @connorjburton introduced to us