### PR TITLE
Fixes composer install (htttps)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     },
     {
       "type": "package",

--- a/lib/timber-twig.php
+++ b/lib/timber-twig.php
@@ -269,7 +269,7 @@ class TimberTwig {
 		}
 
 		if ( $date instanceof DateTime ) {
-			$timestamp = $date->getTimestamp();
+			$timestamp = $date->getTimestamp() + $date->getOffset();
 		} else if (is_numeric( $date ) && strtotime( $date ) === false ) {
 			$timestamp = intval( $date );
 		} else {

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -71,6 +71,13 @@
 			$this->assertEquals('I was modified '.$date, $str);
 		}
 
+		function testInternationalTime(){
+			$date = new DateTime('2015-09-28 05:00:00', new DateTimeZone('europe/amsterdam'));
+			$twig = "{{'" . $date->format('g:i') . "'|date('g:i')}}";
+			$str = Timber::compile_string($twig);
+			$this->assertEquals('05:00', $str);
+		}
+
 		function testModifiedTimeFilter() {
 			$pid = $this->factory->post->create();
 			$post = new TimberPost($pid);


### PR DESCRIPTION
The composer file references `http://wpackagist.org` however that causes an error when doing `composer install` due to https://getcomposer.org/doc/06-config.md#secure-http.

Fix just changes the reference to `https`