### PR TITLE
Updating http reference in composer.json to https

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     },
     {
       "type": "package",


### PR DESCRIPTION
Sorry original PR was branched from a branch.

The composer file references http://wpackagist.org however that causes an error when doing `composer install` due to https://getcomposer.org/doc/06-config.md#secure-http.

Fix just changes the reference to `https`