### PR TITLE
Ref #867 - Fixes timezone when using date filter

### DIFF
--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -75,7 +75,7 @@
 			$date = new DateTime('2015-09-28 05:00:00', new DateTimeZone('europe/amsterdam'));
 			$twig = "{{'" . $date->format('g:i') . "'|date('g:i')}}";
 			$str = Timber::compile_string($twig);
-			$this->assertEquals('05:00', $str);
+			$this->assertEquals('5:00', $str);
 		}
 
 		function testModifiedTimeFilter() {


### PR DESCRIPTION
This solves #867 - also added test to confirm functionality.

#### Issue
```php
$context['amsterdam'] = new DateTime('now', new DateTimeZone('europe/amsterdam'));
```

```twig
{{ amsterdam|date('g') }}
```

Will return the wrong time.

The `date` filter does not honour the `DateTimeZone`

#### Solution
We add the offset of the timezone onto the date (offset can be negative, so `04:00 + -1 = 03:00`)

#### Impact
None

#### Usage
No change

#### Considerations
There may be more instances of this, we need to be aware of honouring timezone offsets.