### PR TITLE
[Needs Review] Ref #836 - Allow to preview when using TimberPost

### DIFF
--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -248,6 +248,23 @@
 			$this->assertEquals($title, trim(strip_tags($post->get_title())));
 		}
 
+		function testPreviewContent(){
+			$quote = 'The way to do well is to do well.';
+			$post_id = $this->factory->post->create(array(
+				'post_content' => $quote
+			));
+			$revision_id = $this->factory->post->create(array(
+				'post_type' => 'revision',
+				'post_parent' => $post_id,
+				'post_content' => $quote . 'Yes'
+			));
+
+			$_GET['preview'] = true;
+			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
+			$post = new TimberPost($post_id);
+			$this->assertEquals($post->post_content, $quote . 'Yes');
+		}
+
 		function testContent(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -273,7 +273,6 @@
 			$user->add_role('administrator');
 			$wp_query->queried_object_id = $post_id;
 			$wp_query->queried_object = get_post($post_id);
-			$revisions = wp_get_post_revisions($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
 			$post = new TimberPost();


### PR DESCRIPTION
This solves #836. This needs review as it touches a few important bits of code. @jarednova 

Also still needs tests that I will write once functionality is complete.

#### Issue
If you use `TimberPost` in your PHP files and try to preview the page it won't show any previews.

#### Solution
If `$_GET['preview']` is set and the `nonce` verifies we then go onto to test if the current user _should_ be seeing this post/page, if they are we get the latest revision and return the ID of that post.

The ID will also fall back to the original post if a revision isn't found or the user doesn't have permissions to see the post preview.

#### Impact
Possibly bad ones if we miss something.

#### Usage
No change

#### Considerations
Okay a few things:

1. I'm using `$_GET` - is there a wrapper around this? I don't see why `$_GET` wouldn't be fine in this situation, just wondering for consistency
2. At the moment I just check for `edit_posts/pages` and `edit_others_posts/pages`, however does this cover custom post types? I don't think so. What about if a user should be able to see the post but not necessarily be able to edit the page/post, is there another capability type for that?
3. Is there an easier way to do this? The original issue said he just changed it to `Timber::query_post` and it worked, can we hook into that?
4. Do we need to check for passworded posts?