### PR TITLE
876 preview tests

### DIFF
--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -228,25 +228,27 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 		$can[] = 'edit_others_' . $query->queried_object->post_type . 's';
 	 	}
 
-	 	$continue = true;
+	 	$can_preview = false;
 
 	 	foreach( $can as $type ) {
-	 		if( !current_user_can( $type ) ) {
-	 			$continue = false;
+	 		if( current_user_can( $type ) ) {
+	 			$can_preview = true;
 	 			break;
 	 		}
 	 	}
-		
-		if( $continue ) {
-			$revisions = wp_get_post_revisions( $query->queried_object_id );
 
-			if( !empty( $revisions ) ) {
-				$last = end($revisions);
-				return $last->ID;
-			} else {
-				return false;
-			}
+	 	if ( !$can_preview ) {
+	 		return;
+	 	}
+
+		$revisions = wp_get_post_revisions( $query->queried_object_id );
+
+		if( !empty( $revisions ) ) {
+			$last = end($revisions);
+			return $last->ID;
 		}
+
+		return false;
 	}
 
 	/**

--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -365,7 +365,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * @param int $len The number of words that WP should use to make the tease. (Isn't this better than [this mess](http://wordpress.org/support/topic/changing-the-default-length-of-the_excerpt-1?replies=14)?). If you've set a post_excerpt on a post, we'll use that for the preview text; otherwise the first X words of the post_content
 	 * @param bool $force What happens if your custom post excerpt is longer then the length requested? By default (`$force = false`) it will use the full `post_excerpt`. However, you can set this to true to *force* your excerpt to be of the desired length
 	 * @param string $readmore The text you want to use on the 'readmore' link
-	 * @param bool $strip Strip tags? yes or no. tell me!
+	 * @param bool $strip true for default, false for none, string for list of custom attributes
 	 * @param string $end The text to end the preview with (defaults to ...)
 	 * @return string of the post preview
 	 */
@@ -397,7 +397,8 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 			return trim($text);
 		}
 		if ( $strip ) {
-			$text = trim(strip_tags($text));
+			$allowable_tags = (is_string($strip)) ? $strip : null;
+			$text = trim(strip_tags($text, $allowable_tags));
 		}
 		if ( strlen($text) ) {
 			$text = trim($text);

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -98,4 +98,17 @@
 			$this->assertEquals('Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true, 'Read More', true, ' ???'));
 		}
 
+		/**
+		 * @group failing
+		 */
+		function testPreviewWithCustomStripTags() {
+			$pid = $this->factory->post->create(array(
+				'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
+			));
+			$post = new TimberPost($pid);
+			$post->post_excerpt = '';
+			$preview = $post->get_preview(6, true, 'Read More', '<span>');
+			$this->assertEquals('<span>Even in the world of</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $preview);
+		}
+
 	}

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -248,6 +248,37 @@
 			$this->assertEquals($title, trim(strip_tags($post->get_title())));
 		}
 
+		function testPreviewContent(){
+			global $current_user;
+			global $wp_query;
+
+			$quote = 'The way to do well is to do well.';
+			$post_id = $this->factory->post->create(array(
+				'post_content' => $quote,
+				'post_author' => 5
+			));
+			$revision_id = $this->factory->post->create(array(
+				'post_type' => 'revision',
+				'post_status' => 'inherit',
+				'post_parent' => $post_id,
+				'post_content' => $quote . 'Yes'
+			));
+
+			$uid = $this->factory->user->create(array(
+				'user_login' => 'timber',
+				'user_pass' => 'timber',
+			));
+			$user = wp_set_current_user($uid);
+
+			$user->add_role('administrator');
+			$wp_query->queried_object_id = $post_id;
+			$wp_query->queried_object = get_post($post_id);
+			$_GET['preview'] = true;
+			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
+			$post = new TimberPost();
+			$this->assertEquals($post->post_content, $quote . 'Yes');
+		}
+
 		function testContent(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
@@ -558,13 +589,24 @@
 			$this->assertEquals('My Page', $post->title());
 		}
 
+		/**
+		 * @group failing
+		 */
 		function testEditUrl() {
-			$pid = $this->factory->post->create(array('post_author' => 1));
+			ini_set("log_errors", 1);
+			ini_set("error_log", "/tmp/php-error.log");
+			
+			global $current_user;
+			$current_user = array();
+
+			$uid = $this->factory->user->create();
+			$pid = $this->factory->post->create(array('post_author' => $uid));
 			$post = new TimberPost($pid);
 			$edit_url = $post->edit_link();
 			$this->assertEquals('', $edit_url);
-			wp_set_current_user(1);
-			$data = get_userdata(1);
+			$user = wp_set_current_user($uid);
+			$user->add_role('administrator');
+			$data = get_userdata($uid);
 			$this->assertTrue($post->can_edit());
 			$this->assertEquals('http://example.org/wp-admin/post.php?post='.$pid.'&amp;action=edit', $post->get_edit_url());
 			//

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -276,7 +276,7 @@
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
 			$post = new TimberPost();
-			$this->assertEquals($post->post_content, $quote . 'Yes');
+			$this->assertEquals( $quote . 'Yes', $post->post_content );
 		}
 
 		function testContent(){
@@ -595,7 +595,7 @@
 		function testEditUrl() {
 			ini_set("log_errors", 1);
 			ini_set("error_log", "/tmp/php-error.log");
-			
+
 			global $current_user;
 			$current_user = array();
 


### PR DESCRIPTION
This picks up #876:

@connorjburton I made two changes I want to call your attention to.

First on `TimberPost::get_post_preview_id` I switched the assumption on true/false. For security reasons (admittedly, hypothetical) it's better practice to start with a no-access assumption. That way if something screwy happens with permissions, the code makes the assumption that viewing the post preview should _not_ be allowed.

On the test itself (`testPreviewContent`), PHPUnit assertEquals compares:

```
$this->assertEquals( Expected Thing, Thing to Test );
```

The test will still pass either way, but the formatting of errors/failures will read correctly. 

All this is just tweaks on your earlier work — give it a look and if you like what you see this should be good to (finally) merge!