### PR TITLE
Adding trim around get_widgets

### DIFF
--- a/lib/timber.php
+++ b/lib/timber.php
@@ -348,7 +348,7 @@ class Timber {
 	 * @return TimberFunctionWrapper
 	 */
 	public static function get_widgets( $widget_id ) {
-		return TimberHelper::function_wrapper( 'dynamic_sidebar', array( $widget_id ), true );
+		return trim( TimberHelper::function_wrapper( 'dynamic_sidebar', array( $widget_id ), true ) );
 	}
 
 


### PR DESCRIPTION
Fixes #511 

#### Issue
If you are using a plugin such as Display Widgets of Dynamic Widgets, the sidebar may be active but not actually containing content, as you can choose which widgets in a sidebar are shown on what page, however `is_active_sidebar` will only check if a sidebar has _any_ widgets.

#### Solution
We just `trim` the result so that we don't have any empty content.

Normally I wouldn't put a fix in for plugin compatibility (massive rabbit-hole) however this is literally just a `trim`.

#### Impact
None

#### Usage
No change

#### Considerations
I can't see how this would effect any existing code, if you do a trim in `twig` as some people were suggesting in #511 it will still work.