### PR TITLE
Timber::get_posts('custom-post-type') ensures class is child

### DIFF
--- a/lib/timber-post-getter.php
+++ b/lib/timber-post-getter.php
@@ -90,7 +90,7 @@ class TimberPostGetter {
 	 * @return bool
 	 */
 	static function is_post_class_or_class_map($arg){
-		if (is_string($arg) && class_exists($arg)) {
+		if (is_string($arg) && (class_exists($item) && is_subclass_of($item, 'TimberPost'))) {
 			return true;
 		}
 		if (is_array($arg)) {

--- a/lib/timber-post-getter.php
+++ b/lib/timber-post-getter.php
@@ -90,7 +90,7 @@ class TimberPostGetter {
 	 * @return bool
 	 */
 	static function is_post_class_or_class_map($arg){
-		if (is_string($arg) && (class_exists($item) && is_subclass_of($item, 'TimberPost'))) {
+		if (is_string($arg) && (class_exists($arg) && is_subclass_of($arg, 'TimberPost'))) {
 			return true;
 		}
 		if (is_array($arg)) {


### PR DESCRIPTION
Hard to fix description into title! This is just an extension of #847, for calls like `Timber::get_posts('cpt')`.