### PR TITLE
post.parent.children now will only return published posts

### DIFF
--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -674,7 +674,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 		if ( $post_type == 'parent' ) {
 			$post_type = $this->post_type;
 		}
-		$children = get_children('post_parent=' . $this->ID . '&post_type=' . $post_type . '&numberposts=-1&orderby=menu_order title&order=ASC');
+		$children = get_children('post_parent=' . $this->ID . '&post_type=' . $post_type . '&numberposts=-1&orderby=menu_order title&order=ASC&post_status=publish');
 		foreach ( $children as &$child ) {
 			$child = new $childPostClass($child->ID);
 		}


### PR DESCRIPTION
Fixes #677 

#### Issue
`post.parent.children` will return all children of that post, regardless of status, as described in the codex here. https://codex.wordpress.org/Function_Reference/get_children

#### Solution
Explicity requests `publish`ed children only.

#### Impact
Maybe someone somewhere is using this and doesn't realise their children are not published.. maybe but I doubt it.

#### Usage
No change

#### Considerations
None