### PR TITLE
Allowing allowable_tags customization

### DIFF
--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -330,7 +330,7 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * @param int $len The number of words that WP should use to make the tease. (Isn't this better than [this mess](http://wordpress.org/support/topic/changing-the-default-length-of-the_excerpt-1?replies=14)?). If you've set a post_excerpt on a post, we'll use that for the preview text; otherwise the first X words of the post_content
 	 * @param bool $force What happens if your custom post excerpt is longer then the length requested? By default (`$force = false`) it will use the full `post_excerpt`. However, you can set this to true to *force* your excerpt to be of the desired length
 	 * @param string $readmore The text you want to use on the 'readmore' link
-	 * @param bool $strip Strip tags? yes or no. tell me!
+	 * @param bool $strip true for default, false for none, string for list of custom attributes
 	 * @param string $end The text to end the preview with (defaults to ...)
 	 * @return string of the post preview
 	 */
@@ -362,7 +362,8 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 			return trim($text);
 		}
 		if ( $strip ) {
-			$text = trim(strip_tags($text));
+			$allowable_tags = (is_string($strip)) ? $strip : null;
+			$text = trim(strip_tags($text, $allowable_tags));
 		}
 		if ( strlen($text) ) {
 			$text = trim($text);

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -98,4 +98,17 @@
 			$this->assertEquals('Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true, 'Read More', true, ' ???'));
 		}
 
+		/**
+		 * @group failing
+		 */
+		function testPreviewWithCustomStripTags() {
+			$pid = $this->factory->post->create(array(
+				'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
+			));
+			$post = new TimberPost($pid);
+			$post->post_excerpt = '';
+			$preview = $post->get_preview(6, true, 'Read More', '<span>');
+			$this->assertEquals('<span>Even in the world of</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $preview);
+		}
+
 	}


### PR DESCRIPTION
Fixes #130 

#### Issue
You can't customize what tags `get_preview` returns

#### Solution
Allows the `$strip` param to accept a string of tags to strip whilst keeping original `true`/`false` functionality and not effecting the `$strip` tag itself so when it's used later on in the function everything else works as before.

#### Impact
None

#### Usage
`get_preview(length, force, readmore, tags, end);`

#### Considerations
None