### PR TITLE
[Needs Review] Auto register classes based on post type

### DIFF
--- a/lib/timber-post-getter.php
+++ b/lib/timber-post-getter.php
@@ -90,7 +90,13 @@ class TimberPostGetter {
 	 * @return bool
 	 */
 	static function is_post_class_or_class_map($arg){
-		$type = (is_string($arg)) ? $arg : (is_array($arg) && isset($arg['post_type'])) ? $arg['post_type'] : false;
+		$type = false;
+
+		if(is_string($arg)) {
+			$type = $arg;
+		} else if(is_array($arg) && isset($arg['post_type'])) {
+			$type = $arg['post_type'];
+		}
 
 		if(!$check) return false;
 

--- a/lib/timber-post-getter.php
+++ b/lib/timber-post-getter.php
@@ -32,8 +32,8 @@ class TimberPostGetter {
 	 * @return array|bool|null
 	 */
 	static function query_posts($query = false, $PostClass = 'TimberPost' ) {
-		if (self::is_post_class_or_class_map($query)) {
-			$PostClass = $query;
+		if ($type = self::is_post_class_or_class_map($query)) {
+			$PostClass = $type;
 			$query = false;
 		}
 
@@ -90,15 +90,12 @@ class TimberPostGetter {
 	 * @return bool
 	 */
 	static function is_post_class_or_class_map($arg){
-		if (is_string($arg) && class_exists($arg)) {
-			return true;
-		}
-		if (is_array($arg)) {
-			foreach ($arg as $item) {
-				if (is_string($item) && (class_exists($item) && is_subclass_of($item, 'TimberPost'))) {
-					return true;
-				}
-			}
+		$type = (is_string($arg)) ? $arg : (is_array($arg) && isset($arg['post_type'])) ? $arg['post_type'] : false;
+
+		if(!$check) return false;
+
+		if (class_exists($type) && is_subclass_of($type, 'TimberPost')) {
+			return $type;
 		}
 	}
 }


### PR DESCRIPTION
Sorry this is a long one, but I think it's important to get this code right as I think it's a bit confused at the moment, and I may be mis-understanding it's purpose.

Fixes #799 and replaces #847

#### Issue
After investigating #799 I realise the function that checks for auto registering could have some nasty side effects and in some instances won't work as expected. Take the example below:

```php
class cpt extends TimberPost {}

# 1.
Timber::get_posts(array(
    'post_type' => 'cpt'
));
# doesn't work

# 2.
Timber::get_posts('cpt');
# works

# 3.
Timber::get_posts(array(
    'name' => 'cpt',
    'post_type' => 'page'
));
# if i did a simple fix, would return the cpt class, however we are querying a page, not a cpt
```

So in the code there were a couple of issues, it was checking if any of the array properties you passed to `Timber::get_posts` matched any classes that extended `TimberPost`, which can lead to some confusing bugs (3). However, I also noted the function just returned `true`, but when it came to the `if` statement, it'd replace the `$PostClass` with the first parameter you passed into `Timber::get_posts`, which would be an array (1), which doesn't seem to be what `$PostClass` should be, but maybe im jumping to conclusions here? And finally, it's undocumented but if you just pass the `post_type` name as the first parameter it will use the class (1).

#### Solution
Refactored the function to:

1. Just have 1 check for if the class exists
2. If the first parameter is an array, only check if `post_type` has a matching class, not every property
3. Always assign a string to `$PostClass`

#### Impact
This is obviously an important function, so goes without saying it needs eyes on it.

#### Usage
```php
TimberPost::get_posts(array(
    'post_type' => 'cpt'
));
# Returns the cpt class
```

#### Considerations
Auto assigning the class by `post_type` or the first parameter being a string is *not* documented and I think right now it's fairly confusing if this is even supposed to happen or not. I think the refactor I have done makes more sense, it's more explicit and what I would personally expect in terms of "Magic".

Currently (and with this fix) if you run `Timber::get_posts(array('post_type' => 'cpt', 'posts_per_page' => -1));` on a `single.php` page, it won't return all the `cpt`s, it will only return the one you are on. That's because when it matches a class it will remove the original query and just assume you want the class. Maybe it should carry over the query too?