### PR TITLE
Fixing extra slash on images not in year/month folders

### DIFF
--- a/lib/timber-image-helper.php
+++ b/lib/timber-image-helper.php
@@ -351,7 +351,7 @@ class TimberImageHelper {
 			}
 		}
 		$parts = pathinfo($tmp);
-		$result['subdir'] = $parts['dirname'];
+		$result['subdir'] = ($parts['dirname'] === '/') ? '' : $parts['dirname'];
 		$result['filename'] = $parts['filename'];
 		$result['extension'] = $parts['extension'];
 		$result['basename'] = $parts['basename'];

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -803,6 +803,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals($image->src(), $result);
 	}
 
+	/**
+	 * @group failing
+	 */
 	function testTimberImageForExtraSlashes() {
 		add_filter('upload_dir', array($this, '_filter_upload'), 10, 1);
 
@@ -813,7 +816,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 		remove_filter('upload_dir', array($this, '_filter_upload'));
 
-		$this->assertFalse(strpos($resized_520_file, '//') > -1);
+		$this->assertFalse(strpos($resized_520_file, '//arch-520x500-c-default.jpg') > -1);
 	}
 
 	function _filter_upload($data) {

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -804,14 +804,6 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testTimberImageForExtraSlashes() {
-		require_once('wp-overrides.php');
-
-		$dir = wp_upload_dir();
-		$originals = array(
-			'dir' => $dir['path'],
-			'url' => $dir['url']
-		);
-
 		add_filter('upload_dir', array($this, '_filter_upload'), 10, 1);
 
 		$post = $this->get_post_with_image();

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -803,9 +803,6 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals($image->src(), $result);
 	}
 
-	/**
-	 * @group failing
-	 */
 	function testTimberImageForExtraSlashes() {
 		add_filter('upload_dir', array($this, '_filter_upload'), 10, 1);
 

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -803,4 +803,32 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals($image->src(), $result);
 	}
 
+	function testTimberImageForExtraSlashes() {
+		require_once('wp-overrides.php');
+
+		$dir = wp_upload_dir();
+		$originals = array(
+			'dir' => $dir['path'],
+			'url' => $dir['url']
+		);
+
+		add_filter('upload_dir', array($this, '_filter_upload'), 10, 1);
+
+		$post = $this->get_post_with_image();
+		$image = $post->thumbnail();
+
+		$resized_520_file = TimberImageHelper::resize($image->src, 520, 500);
+
+		remove_filter('upload_dir', array($this, '_filter_upload'));
+
+		$this->assertFalse(strpos($resized_520_file, '//') > -1);
+	}
+
+	function _filter_upload($data) {
+		$data['path'] = $data['basedir'];
+		$data['url'] = $data['baseurl'];
+
+		return $data;
+	}
+
 }


### PR DESCRIPTION
Fixes #498

#### Issue
If your settings are to *not* upload in year/month folders, when you get file info the `subdir` will be `/` which causes a double `/` before the image filename, e.g

`http://site.com/wp-content/uploads//1024x1024-400x400x-c-default.jpg`

#### Solution
Don't register the `/` if it's on its own.

#### Impact
None

#### Usage
No change

#### Considerations
I think this will fix #498, but they were reporting backwards slash, but I am thinking that is due to system environment.