### PR TITLE
docs: Fix broken anchor link

### DIFF
--- a/docs/wiki/getting-started-setup.md
+++ b/docs/wiki/getting-started-setup.md
@@ -42,4 +42,4 @@ It will be in wp-admin/plugins.php
 Make sure you select the Timber-enabled theme **after** you activate the plugin. The theme will crash unless Timber is activated. Use the **timber-starter-theme** theme from the step above (or whatever you renamed it).
 
 ### 3. Let's write our theme!
-Continue ahead in [Part 2](getting-started)
+Continue ahead in [Part 2](#getting-started-themeing)


### PR DESCRIPTION
the link is in the 3rd step here http://jarednova.github.io/timber/#use-the-starter-theme