### PR TITLE
Fixing issue with tojpg not being deleted

### DIFF
--- a/lib/timber-image-helper.php
+++ b/lib/timber-image-helper.php
@@ -210,6 +210,8 @@ class TimberImageHelper {
 		$filename = $info['filename'];
 		self::process_delete_generated_files( $filename, $ext, $dir, '-[0-9999999]*', '-[0-9]*x[0-9]*-c-[a-z]*.' );
 		self::process_delete_generated_files( $filename, $ext, $dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.' );
+		self::process_delete_generated_files( $filename, 'jpg', $dir, '-tojpg.*' );
+		self::process_delete_generated_files( $filename, 'jpg', $dir, '-tojpg-[0-9999999]*' );
 	}
 
 	/**
@@ -226,13 +228,13 @@ class TimberImageHelper {
 	 * @param string 	$search_pattern pattern of files to pluck from
 	 * @param string 	$match_pattern pattern of files to go forth and delete
 	 */
-	protected static function process_delete_generated_files( $filename, $ext, $dir, $search_pattern, $match_pattern ) {
+	protected static function process_delete_generated_files( $filename, $ext, $dir, $search_pattern, $match_pattern = null ) {
 		$searcher = '/' . $filename . $search_pattern;
 		foreach ( glob( $dir . $searcher ) as $found_file ) {
 			$regexdir = str_replace( '/', '\/', $dir );
 			$pattern = '/' . ( $regexdir ) . '\/' . $filename . $match_pattern . $ext . '/';
 			$match = preg_match( $pattern, $found_file );
-			if ( $match ) {
+			if ( ! $match_pattern || $match ) {
 				unlink( $found_file );
 			}
 		}


### PR DESCRIPTION
Fixes #894 

#### Issue
Some JPG files are not deleted, when they were generated through [`tojpg` Twig filter](https://github.com/jarednova/timber/wiki/Image-cookbook#converting-images) that was used on a PNG file.

#### Solution
Change generated `tojpg` files to have `tojpg` in the filename.
Added two more calls to `delete_generated_files` with specific regex for the `tojpg`

#### Impact
Negligibly slower

#### Usage
No change

#### Considerations
I tried combining the two calls to one, but couldn't get it to work with `glob` correctly.