### PR TITLE
Fixing next link showing up in pagination with no posts

### DIFF
--- a/lib/timber.php
+++ b/lib/timber.php
@@ -436,6 +436,9 @@ class Timber {
 		if ( $paged < 2 ) {
 			$data['prev'] = '';
 		}
+		if ( $data['total'] === ( double ) 0 ) {
+			$data['next'] = '';
+		}
 		return $data;
 	}
 


### PR DESCRIPTION
Fixes #639

#### Issue
If you have an archive with no posts, yet use `Timber::get_pagination`, `next` will return a link.

#### Solution
Overrides the array property to an empty string if `total` is `0`

#### Impact
I can't think of any backwards compatibility issues here

#### Usage
No change

#### Considerations
None